### PR TITLE
Add missing class in the navigation component doc

### DIFF
--- a/docs/_component/responsive-navigation/component-wp.html
+++ b/docs/_component/responsive-navigation/component-wp.html
@@ -1,5 +1,5 @@
 <nav class="site-navigation" role="navigation" itemscope="itemscope" itemtype="https://schema.org/SiteNavigationElement">
-  <a href="#primary-nav" aria-controls="primary-nav">
+  <a href="#primary-nav" aria-controls="primary-nav" class="site-menu-toggle">
     <span class="screen-reader-text">Primary Menu</span>
     <span aria-hidden="true">☰</span>
   </a>

--- a/docs/_component/responsive-navigation/component.html
+++ b/docs/_component/responsive-navigation/component.html
@@ -1,5 +1,5 @@
 <nav class="site-navigation" role="navigation" itemscope="itemscope" itemtype="https://schema.org/SiteNavigationElement">
-  <a href="#primary-nav" aria-controls="primary-nav">
+  <a href="#primary-nav" aria-controls="primary-nav" class="site-menu-toggle">
     <span class="screen-reader-text">Primary Menu</span>
     <span aria-hidden="true">☰</span>
   </a>

--- a/packages/navigation/README.md
+++ b/packages/navigation/README.md
@@ -36,7 +36,7 @@
  ```html
 <nav class="site-navigation" role="navigation" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
 
-	<a href="#primary-nav" aria-controls="primary-nav">
+	<a href="#primary-nav" aria-controls="primary-nav" class="site-menu-toggle">
 		<span class="screen-reader-text">Primary Menu</span>
 		<span aria-hidden="true">☰</span>
 	</a>


### PR DESCRIPTION
### Description of the Change

This change adds a missing class in the navigation component documentation. That way, the navigation toggle disappears when resizing from mobile to desktop.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

This has been tested manually.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes: #28 
