### PR TITLE
Update tabs.js

### DIFF
--- a/packages/tabs/src/tabs.js
+++ b/packages/tabs/src/tabs.js
@@ -321,7 +321,7 @@ export default class Tabs {
 		}
 
 		// Change state of newly selected tab.
-		const newTab = isEvent ? tab.target : tabItems[tab];
+		const newTab = isEvent ? tab.currentTarget : tabItems[tab];
 
 		if (newTab) {
 			const newTabId = newTab.getAttribute('aria-controls');

--- a/packages/tabs/src/tabs.js
+++ b/packages/tabs/src/tabs.js
@@ -197,7 +197,7 @@ export default class Tabs {
 			this.addEventListener(tabLink, 'click', (event) => {
 				event.preventDefault();
 
-				if (!event.target.parentNode.classList.contains('is-active')) {
+				if (!event.currentTarget.parentNode.classList.contains('is-active')) {
 					this.goToTab(event, tabArea);
 				}
 			});


### PR DESCRIPTION
### Description of the Change

This is a minor change to handle targeting the click event in the case where you have nested elements within your tab links.

Example of the HTML markup that this impacts: Notice the nested `span` within the tab link markup

```
<a role="tab" id="tab-products" aria-controls="products" class="products-search-tab" aria-selected="true">
							Products <span class="count">(13)</span>
						</a>
```

When utilizing  `.addEventListener` with a click event:

* `event.target` refers to the element that triggered the event (i.e. the element the user clicked on)
* `event.currentTarget` refers to the element that the event listener is attached to.

This is very important in this case because when you click on the span, the tab target content will actually be `null` by utilizing `event.currentTarget` instead, you then negate any child elements of the tab click event

### Alternate Designs

I did not research any other alternatives as this is pretty standard

### Benefits

Backward compatible with the current implementation and allows for a more complex HTML structure without breaking tab functionality

### Possible Drawbacks

None that I came across

### Verification Process

- Tested on major browsers as of this Pull request creation
- Testing is easy to replicate. Create a tab link with an element within it `<span>` are pretty realistic, click on the span with the current code base, you will see it break will result in no tab showing. By changing the event you will see that even clicking on the span the event will bubble properly

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] All new and existing tests passed.

