### PR TITLE
adds menu ID to submenu ID to prevent duplicate IDs

### DIFF
--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/component-navigation",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": "10up",
   "description": "Accessible navigation component.",
   "main": "dist/index.js",

--- a/packages/navigation/src/navigation.js
+++ b/packages/navigation/src/navigation.js
@@ -200,9 +200,10 @@ export default class Navigation {
 	 * Adds JS classes and initial AIRA attributes.
 	 */
 	setupSubMenus() {
-		this.$submenus.forEach(($submenu) => {
+		const id = this.$menu.getAttribute('id');
+		this.$submenus.forEach(($submenu, index) => {
 			const $anchor = $submenu.previousElementSibling;
-			const submenuID = `tenUp-submenu-${crypto.randomUUID()}`;
+			const submenuID = `tenUp-submenu-${id}-${index}`;
 
 			$submenu.setAttribute('id', submenuID);
 

--- a/packages/navigation/src/navigation.js
+++ b/packages/navigation/src/navigation.js
@@ -200,9 +200,9 @@ export default class Navigation {
 	 * Adds JS classes and initial AIRA attributes.
 	 */
 	setupSubMenus() {
-		this.$submenus.forEach(($submenu, index) => {
+		this.$submenus.forEach(($submenu) => {
 			const $anchor = $submenu.previousElementSibling;
-			const submenuID = `tenUp-submenu-${index}`;
+			const submenuID = `tenUp-submenu-${crypto.randomUUID()}`;
 
 			$submenu.setAttribute('id', submenuID);
 

--- a/packages/navigation/src/navigation.js
+++ b/packages/navigation/src/navigation.js
@@ -200,7 +200,7 @@ export default class Navigation {
 	 * Adds JS classes and initial AIRA attributes.
 	 */
 	setupSubMenus() {
-		const id = this.$menu.getAttribute('id');
+		const id = this.$menu.getAttribute('id') ?? '';
 		this.$submenus.forEach(($submenu, index) => {
 			const $anchor = $submenu.previousElementSibling;
 			const submenuID = `tenUp-submenu-${id}-${index}`;


### PR DESCRIPTION
### Description of the Change

Adds the parent menu ID to the submenu IDs to ensure unique IDs. This change prevents duplicate IDs.

### Alternate Designs

An alternative solution is to use the Web Crypto API (randomUUID) or the UUID package.

### Benefits

This change will prevent duplicate IDs on the page, which fails validation and has a11y implications, when using multiple navigation components on the same page.

### Possible Drawbacks

n/a

### Verification Process

I built the code `npm run build` and confirmed the change on a project that was affected by #141.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#141 
