### PR TITLE
Feature/issue 151 focus nested accordions with keyboard navigation

### DIFF
--- a/packages/accordion/src/__tests__/accordion.js
+++ b/packages/accordion/src/__tests__/accordion.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/dom';
+import { screen, fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { render, injectCSS } from 'test-utils/dom';
 import { axe } from 'jest-axe';
@@ -39,7 +39,7 @@ beforeEach(() => {
 				</div> <!-- //.accordion -->
 			</div> <!-- //.accordion-content -->
 
-			<button class="accordion-header" type="button">Accordion Header</button>
+			<button class="accordion-header" type="button">Accordion Header 4</button>
 			<div class="accordion-content">
 				<h2 class="accordion-label">Accordion Heading</h2>
 				<p>here the content of 4th tab <a href="#">link</a></p>
@@ -179,6 +179,39 @@ test('nested accordion works', async () => {
 
 	userEvent.click(nestedAccordionHeader);
 	expect(nestedAccordionContent).not.toBeVisible();
+});
+
+test('keyboard navigation works', async () => {
+	new Accordion('.accordion');
+
+	const header1 = screen.getByText('Accordion Header 1');
+	const header2 = screen.getByText('Accordion Header 2');
+	const nestedAccordionHeader = screen.getByText('Accordion Header with Nested Accordion');
+	const nestedAccordionContent = screen.getByTestId('accordion-content-nested');
+	const subAccordionHeader = screen.getAllByText('Nested Accordion Header');
+	const header4 = screen.getByText('Accordion Header 4');
+
+	fireEvent.keyDown(header1, { key: 'ArrowDown' });
+	expect(header2).toHaveFocus();
+
+	fireEvent.keyDown(header2, { key: 'ArrowUp' });
+	expect(header1).toHaveFocus();
+
+	fireEvent.click(nestedAccordionHeader);
+	expect(nestedAccordionContent).toBeVisible();
+	expect(await axe(document.querySelector('.accordion'))).toHaveNoViolations();
+
+	fireEvent.keyDown(nestedAccordionHeader, { key: 'ArrowDown' });
+	expect(subAccordionHeader[0]).toHaveFocus();
+
+	fireEvent.keyDown(subAccordionHeader[0], { key: 'ArrowDown' });
+	expect(subAccordionHeader[1]).toHaveFocus();
+
+	fireEvent.keyDown(subAccordionHeader[1], { key: 'Home' });
+	expect(header1).toHaveFocus();
+
+	fireEvent.keyDown(header1, { key: 'End' });
+	expect(header4).toHaveFocus();
 });
 
 test('destroying accordion works', async () => {

--- a/packages/accordion/src/accordion.js
+++ b/packages/accordion/src/accordion.js
@@ -152,7 +152,7 @@ export default class Accordion {
 		// Handle keydown event to move between accordion items
 		this.addEventListener(accordionArea, 'keydown', (event) => {
 			const selectedElement = event.target;
-			const key = event.which;
+			const { key } = event;
 
 			// Make sure the selected element is a header and a direct descendant of the current accordionArea
 			if (
@@ -288,17 +288,17 @@ export default class Accordion {
 
 		switch (key) {
 			// End key
-			case 35:
+			case 'End':
 				linkIndex = accordionLinks.length - 1;
 				event.preventDefault();
 				break;
 			// Home key
-			case 36:
+			case 'Home':
 				linkIndex = 0;
 				event.preventDefault();
 				break;
 			// Up arrow
-			case 38:
+			case 'ArrowUp':
 				linkIndex--;
 				if (linkIndex < 0) {
 					linkIndex = accordionLinks.length - 1;
@@ -306,7 +306,7 @@ export default class Accordion {
 				event.preventDefault();
 				break;
 			// Down arrow
-			case 40:
+			case 'ArrowDown':
 				linkIndex++;
 				if (linkIndex > accordionLinks.length - 1) {
 					linkIndex = 0;

--- a/packages/accordion/src/accordion.js
+++ b/packages/accordion/src/accordion.js
@@ -6,6 +6,7 @@ export default class Accordion {
 	 * @param options The acccordion options.
 	 */
 	constructor(element, options = {}) {
+		this.element = element;
 		this.evtCallbacks = {};
 
 		// Defaults
@@ -149,19 +150,26 @@ export default class Accordion {
 	setupAccordion(accordionArea, accordionAreaIndex) {
 		const [accordionLinks, accordionContent] = this.getAccordionLinksAndContent(accordionArea);
 
-		// Handle keydown event to move between accordion items
-		this.addEventListener(accordionArea, 'keydown', (event) => {
-			const selectedElement = event.target;
-			const { key } = event;
+		// Add keydown event only to top level content areas.
+		if (!this.isNestedAccordionArea(accordionArea)) {
+			// Handle keydown event to move between accordion items
+			this.addEventListener(accordionArea, 'keydown', (event) => {
+				const selectedElement = event.target;
+				const { key } = event;
 
-			// Make sure the selected element is a header and a direct descendant of the current accordionArea
-			if (
-				selectedElement.classList.contains('accordion-header') &&
-				selectedElement.parentNode === accordionArea
-			) {
-				this.accessKeyBindings(accordionLinks, selectedElement, key, event);
-			}
-		});
+				// Make sure the selected element is a header and is child of an accordionArea
+				if (
+					selectedElement.classList.contains('accordion-header') &&
+					selectedElement.parentNode === selectedElement.closest(this.element)
+				) {
+					const allFocusableAccordionLinks = this.getAllFocusableAccordionLinks(
+						accordionArea,
+					);
+
+					this.accessKeyBindings(allFocusableAccordionLinks, selectedElement, key, event);
+				}
+			});
+		}
 
 		// Set ARIA attributes for accordion links
 		accordionLinks.forEach((accordionLink, index) => {
@@ -319,5 +327,43 @@ export default class Accordion {
 
 		const newLinkIndex = linkIndex;
 		accordionLinks[newLinkIndex].focus();
+	}
+
+	/**
+	 * Check if accordionArea is nested.
+	 *
+	 * @param		{element} accordionArea		The accordionArea to be checked.
+	 *
+	 * @returns	{boolean}
+	 */
+	isNestedAccordionArea(accordionArea) {
+		return !!accordionArea.parentElement.closest(this.element);
+	}
+
+	/**
+	 * Return all accordion links that can receive focus.
+	 *
+	 * @param {element} accordionArea The accordionArea to scope changes.
+	 *
+	 * @returns {Array}
+	 */
+	getAllFocusableAccordionLinks(accordionArea) {
+		const allAccordionLinks = accordionArea.querySelectorAll('.accordion-header');
+		const focusableAccordionLinks = Array.prototype.slice
+			.call(allAccordionLinks)
+			.filter((link) => {
+				const parentAccordionContent = link.closest('.accordion-content');
+
+				if (
+					!parentAccordionContent ||
+					parentAccordionContent.classList.contains('is-active')
+				) {
+					return link;
+				}
+
+				return null;
+			});
+
+		return focusableAccordionLinks;
 	}
 }


### PR DESCRIPTION
### Description of the Change

To get more details, please see issue #151.

1. The deprecated keyboard event property `which` has been replaced with the `key` one. (See [UIEvent: which property](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which) in mdn web docs).
2. The keydown event listener is now added once, only for the top level accordion area.
3. When the user navigates with the keyboard, a fresh list with all focusable accordion links is created and passed in to the `accessKeyBindings` method.
4. Users can access nested accordion links via keyboard navigation.
5. New tests have been created.

### Alternate Designs

Instead of getting a list with all focusable accordion links every time the user press one of the navigation keys (Arrow Up, Arrow Down, Home, and End), another alternative could be creating this list once, and updating it whenever the user opens/closes any accordion. However, this list is only needed for keyboard navigation, so it doesn't make sense to keep it updated if the user may end up never navigating with the keyboard and, therefore, never using the list.

### Benefits

All accordion links will be accessed via keyboard navigation, including the nested ones.

### Possible Drawbacks

None that I came across.

### Verification Process

1. Create accordions with nested accordions.
2. Press the Tab key util one of the accordion links has been focused.
3. Navigate across accordion links with Arrow Up, Arrow Down, Home, and End keyboard keys.
6. Pressing the Arrow Down key focus the immediate next accordion link regardless of it is inside a nested accordion or is on the same level of the current focused accordion link.
    - If the current focused accordion link is the last one, the focus moves to the first accordion link.
7. Pressing the Arrow Up key focus the immediate previous accordion link regardless of it is inside a nested accordion or is on the same level of the current focused accordion link.
    - If the current focused accordion link is the first one, the focus moves to the last accordion link.
8. Pressing the Home key focus the first accordion link.
9. Pressing the End key focus the last accordion link.


### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

### Applicable Issues

Closes #151
