### PR TITLE
Change Support Status to Archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A library of barebones front-end components built with WordPress and accessibility in mind.
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Support Level](https://img.shields.io/badge/support-archived-red.svg)](#support-level) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/10up/component-library/branch/develop/graph/badge.svg?token=rm4ggtw19O)](https://codecov.io/gh/10up/component-library)
 
 
@@ -31,7 +31,7 @@ To use a component, navigate to the component’s detail page to see demos, usag
 
 ## Support Level
 
-**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
+**Archived:** This project is no longer maintained by 10up. We are no longer responding to Issues or Pull Requests unless they relate to security concerns. We encourage interested developers to fork this project and make it their own!
 
 ## Repository Structure and Engineering Guidelines
 Visit the [CONTRIBUTING](/CONTRIBUTING.md) page for initial contribution and engineering guidance.

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages']
+gem 'github-pages', '~> 228'
+gem 'jekyll', '~> 3.9.0'
+gem 'webrick', '~> 1.7'

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -39,4 +39,8 @@
 	</div>
 </header>
 
+<div class="c-maintenance-banner">
+	<p><strong>Notice:</strong> This site is no longer being actively maintained. We are aiming to open source new internal component packages and systems in the future.</p>
+</div>
+
 <main class="main page-{{page.title}}" id="main" role="main">

--- a/docs/assets/css/sass/components/_index.scss
+++ b/docs/assets/css/sass/components/_index.scss
@@ -8,6 +8,7 @@
 @import "example-inline";
 @import "iframe";
 @import "main";
+@import "maintenance-banner";
 @import "meta";
 @import "nav";
 @import "syntax-highlight";

--- a/docs/assets/css/sass/components/_maintenance-banner.scss
+++ b/docs/assets/css/sass/components/_maintenance-banner.scss
@@ -1,0 +1,42 @@
+.c-maintenance-banner {
+	background: #fef3cd;
+	border-bottom: 1px solid #fdc935;
+	color: #856404;
+	padding: $spacing-small $spacing-medium;
+	text-align: center;
+	position: relative;
+	z-index: $elevation-mid;
+
+	@media (min-width: $breakpoint-small) {
+		margin-left: 260px;
+	}
+
+	@media (min-width: $breakpoint-medium) {
+		margin-left: 310px;
+	}
+
+	p {
+		margin: 0;
+		font-size: $font-size-tiny;
+		max-width: none;
+
+		@media (min-width: $breakpoint-small) {
+			font-size: $font-size-xsmall;
+		}
+	}
+
+	a {
+		color: #495057;
+		text-decoration: underline;
+		font-weight: $font-weight-medium;
+
+		&:hover,
+		&:focus {
+			color: #212529;
+		}
+	}
+
+	strong {
+		font-weight: $font-weight-medium;
+	}
+}


### PR DESCRIPTION
This pull request updates the project status to indicate it is no longer maintained and introduces a maintenance notice banner on the documentation site. It also updates documentation dependencies and adds styling for the new banner. The most important changes are:

**Project Status and Communication:**
* Updated `README.md` to mark the project as "Archived" instead of "Active", clarifying that it is no longer maintained and that only security concerns will be addressed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)
* Added a prominent maintenance banner to the documentation site via `header.html` to notify visitors that the site is no longer actively maintained.

**Documentation and Styling:**
* Added a new SCSS file (`_maintenance-banner.scss`) and imported it into the main stylesheet to style the maintenance banner, ensuring it is visually distinct and responsive. [[1]](diffhunk://#diff-e33a0b3ba8c829f1d322b6043181a4ea1afb8552328e0da82c8c669a025b56bdR1-R42) [[2]](diffhunk://#diff-d791937c79032c0553546c61c15e12c7e82d8c8deca9df092ac761e4310b6e3eR11)

_Here is an image of the notice banner on the homepage:_
<img width="3456" height="1948" alt="CleanShot 2025-09-17 at 10 12 26@2x" src="https://github.com/user-attachments/assets/a60ec934-ccd6-47e3-8946-aca15c2311f9" />


**Dependency Updates:**
* Updated the `docs/Gemfile` to specify explicit versions for `github-pages`, `jekyll`, and `webrick`, removing dynamic fetching of versions for more predictable builds.